### PR TITLE
Locale loading fix

### DIFF
--- a/examples/host/main.go
+++ b/examples/host/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/aerogear/charmil/examples/plugins/date"
@@ -17,8 +16,9 @@ func main() {
 
 	dateCmd, err := date.DateCommand()
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	}
+
 	cmd.AddCommand(dateCmd)
 
 	if err := cmd.Execute(); err != nil {

--- a/examples/plugins/date/main.go
+++ b/examples/plugins/date/main.go
@@ -21,7 +21,7 @@ type Options struct {
 func DateCommand() (*cobra.Command, error) {
 
 	// Initialize localizer providing the language, locals and format of locals file
-	loc, err := localize.InitLocalizer(localize.Config{Language: language.English, Path: "examples/plugins/date/locals/en/en.yaml", Format: "yaml"})
+	loc, err := localize.InitLocalizer(localize.Config{Language: language.English, Path: "examples/plugins/date/locales/en/en.yaml", Format: "yaml"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/localize/i18n.go
+++ b/pkg/localize/i18n.go
@@ -69,7 +69,10 @@ func InitLocalizer(cfg Config) (*GoI18n, error) {
 
 	// load translations during initialization
 	bundle.RegisterUnmarshalFunc(cfg.Format, unmarshalFunc)
-	bundle.LoadMessageFile(cfg.Path)
+	_, err := bundle.LoadMessageFile(cfg.Path)
+	if err != nil {
+		return nil, err
+	}
 
 	loc := &GoI18n{
 		language:  &cfg.Language,


### PR DESCRIPTION
### Description
When running the host binary a panic occurred when localizing the date command. 
- Fixed path given to the config in the `InitLocalizer` func
- Added error handling for loading the config file
- Changed `Println` to `Fatal` as not exiting will panic anyway and obfuscate the error

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer