### PR TITLE
Feature: validator command for use with dev builds

### DIFF
--- a/core/commands/charmil.go
+++ b/core/commands/charmil.go
@@ -10,12 +10,19 @@ func AttachCharmilCommands(hostRoot *cobra.Command) error {
 		return nil
 	}
 
-         // Placeholder command. To be replaced later by actual commands
+	// Placeholder command. To be replaced later by actual commands
 	cmd := &cobra.Command{
 		Use:     "charmil",
 		Short:   "built in charmil commands",
 		SilenceUsage: false,
 	}
+
+	// charmil custom commands
+	validateCommand ,err := ValidateCommand()
+	if err != nil {
+		return err
+	}
+	cmd.AddCommand(validateCommand)
 
 	hostRoot.AddCommand(cmd)
 	return nil

--- a/core/commands/validator.go
+++ b/core/commands/validator.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	factory2 "github.com/aerogear/charmil/core/factory"
+	"github.com/aerogear/charmil/validator/rules"
+	"github.com/spf13/cobra"
+)
+
+func ValidateCommand() (*cobra.Command, error) {
+
+	cmd := &cobra.Command{
+		Use:     "validate",
+		Short:   "tests rules on added commands",
+		Long:    "executes all rules defined on each command added",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			var ruleConfig rules.RuleConfig
+			validationErrors := ruleConfig.ExecuteRules(cmd.Root())
+
+			logger := factory2.Default(nil).Logger
+			for _, validationError := range validationErrors {
+				if validationError.Err != nil {
+					logger.Errorf("%v failed rule %v with error: %v\n", validationError.Cmd.Use,
+						validationError.Rule, validationError.Name)
+				}
+			}
+			return nil
+		},
+	}
+
+	return cmd, nil
+}

--- a/validator/rules/executor.go
+++ b/validator/rules/executor.go
@@ -51,6 +51,11 @@ func (config *RuleConfig) executeHelper(cmd *cobra.Command, info *validator.Stat
 func (config *RuleConfig) executeRecursive(cmd *cobra.Command, info *validator.StatusLog) []validator.ValidationError {
 
 	for _, child := range cmd.Commands() {
+
+		if child.Use == "charmil"{
+			continue
+		}
+
 		// base case
 		if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {
 			continue
@@ -67,6 +72,10 @@ func (config *RuleConfig) executeRecursive(cmd *cobra.Command, info *validator.S
 func (config *RuleConfig) executeRulesChildren(cmd *cobra.Command, info *validator.StatusLog) []validator.ValidationError {
 	children := cmd.Commands()
 	for _, child := range children {
+
+		if child.Use == "charmil"{
+			continue
+		}
 
 		if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {
 			continue

--- a/validator/rules/executor.go
+++ b/validator/rules/executor.go
@@ -85,7 +85,7 @@ func (config *RuleConfig) executeRulesChildren(cmd *cobra.Command, info *validat
 	return info.Errors
 }
 
-// validate returns validation errors by executing the rules
+// validate populates info with stats on the rules executed
 func (config *RuleConfig) validate(cmd *cobra.Command, info *validator.StatusLog) {
 
 	rules := []Rules{
@@ -97,8 +97,8 @@ func (config *RuleConfig) validate(cmd *cobra.Command, info *validator.StatusLog
 		validationErrors := rule.Validate()
 		info.TotalErrors += len(validationErrors)
 		info.Errors = append(info.Errors, validationErrors...)
-		info.TotalTested++
 	}
+	info.TotalTested++
 
 }
 


### PR DESCRIPTION
### Description
Added a command called validate that can be used when a host build with the dev tag. This command runs validate on all non-charmil commands that the host command contains.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [ ] Code Review completed
- [ ] Verified independently by reviewer

## Screenshots
Validate command is ran on a dev build which prints the commands added by the host that fail validation based on the default rule config.
![image](https://user-images.githubusercontent.com/45426048/124338939-8d7e9480-dba2-11eb-83ea-88835cd1d1fd.png)
