### PR TITLE
feat: useMatches rule for Use

### DIFF
--- a/docs/src/validator/validator.md
+++ b/docs/src/validator/validator.md
@@ -20,6 +20,7 @@ ruleCfg := rules.ValidatorConfig{
 	ValidatorRules: rules.ValidatorRules{
 		Length: rules.Length{Limits: map[string]rules.Limit{"Use": {Min: 1}}},
 		MustExist: rules.MustExist{Fields: map[string]bool{"Args": true}},
+		UseMatches: rules.UseMatches{Regexp: `^[^-_+]+$`},
 	},
 }
 ```

--- a/validator/example/cmd.go
+++ b/validator/example/cmd.go
@@ -21,8 +21,7 @@ func NewCommand() *cobra.Command {
 		Short:   "This is the short",
 		Long:    `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis malesuada varius lacus, sit amet dictum risus convallis nec. Quisque suscipit at neque in blandit. Proin a accumsan ante. Aenean cursus suscipit sem. Nunc sollicitudin, ante et vehicula pharetra, mauris elit porta felis, et ultricies nulla justo eleifend justo. Proin sit amet.`,
 		Example: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis malesuada varius lacus, sit amet dictum risus convallis nec. Quisque suscipit at neque in blandit. Proin a accumsan ante. Aenean cursus suscipit sem. Nunc sollicitudin, ante et vehicula pharetra, mauris elit porta felis, et ultricies nulla justo eleifend justo. Proin sit amet.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+		Run: func(cmd *cobra.Command, args []string) {
 		},
 	}
 

--- a/validator/example/cmd_test.go
+++ b/validator/example/cmd_test.go
@@ -18,6 +18,8 @@ func Test_ExecuteCommand(t *testing.T) {
 					"Use": {Min: 1},
 				},
 			},
+			MustExist:  rules.MustExist{Fields: map[string]bool{"Run": true}},
+			UseMatches: rules.UseMatches{Regexp: `^[^-_+]+$`},
 		},
 	}
 

--- a/validator/rules/config.go
+++ b/validator/rules/config.go
@@ -23,8 +23,9 @@ type ValidatorOptions struct {
 // ValidatorRules consists of all the rules
 // present in validator
 type ValidatorRules struct {
-	Length    `json:"Length"`
-	MustExist `json:"MustExist"`
+	Length     `json:"Length"`
+	MustExist  `json:"MustExist"`
+	UseMatches `json:"UseMatches"`
 }
 
 // ExecuteRules executes all the rules
@@ -58,6 +59,9 @@ func ValidatorConfigToRuleConfig(validatorConfig *ValidatorConfig, ruleConfig *R
 				Verbose: defaultVerbose,
 				Fields:  map[string]bool{"Use": true, "Short": true, "Long": true, "Example": true},
 			},
+			UseMatches: UseMatches{
+				Regexp: `^[^-_]+$`,
+			},
 		},
 	}
 
@@ -68,5 +72,10 @@ func ValidatorConfigToRuleConfig(validatorConfig *ValidatorConfig, ruleConfig *R
 	validatorConfig = &configHelper
 
 	// append rules to execute
-	ruleConfig.Rules = append(ruleConfig.Rules, &validatorConfig.Length, &validatorConfig.MustExist)
+	ruleConfig.Rules = append(
+		ruleConfig.Rules,
+		&validatorConfig.Length,
+		&validatorConfig.MustExist,
+		&validatorConfig.UseMatches,
+	)
 }

--- a/validator/rules/config.go
+++ b/validator/rules/config.go
@@ -59,9 +59,6 @@ func ValidatorConfigToRuleConfig(validatorConfig *ValidatorConfig, ruleConfig *R
 				Verbose: defaultVerbose,
 				Fields:  map[string]bool{"Use": true, "Short": true, "Long": true, "Example": true},
 			},
-			UseMatches: UseMatches{
-				Regexp: `^[^-_]+$`,
-			},
 		},
 	}
 

--- a/validator/rules/length.go
+++ b/validator/rules/length.go
@@ -39,10 +39,6 @@ type Length struct {
 // Validate is a method of type Rule Interface
 // which returns validation errors
 func (l *Length) Validate(cmd *cobra.Command) []validator.ValidationError {
-	return l.validateLength(cmd)
-}
-
-func (l *Length) validateLength(cmd *cobra.Command) []validator.ValidationError {
 	var errors []validator.ValidationError
 
 	for fieldName, limits := range l.Limits {

--- a/validator/rules/length.go
+++ b/validator/rules/length.go
@@ -36,6 +36,8 @@ type Length struct {
 	Limits  map[string]Limit `json:"Limits"`
 }
 
+// Validate is a method of type Rule Interface
+// which returns validation errors
 func (l *Length) Validate(cmd *cobra.Command) []validator.ValidationError {
 	return l.validateLength(cmd)
 }

--- a/validator/rules/must_exist.go
+++ b/validator/rules/must_exist.go
@@ -25,6 +25,8 @@ type MustExist struct {
 	Fields  map[string]bool `json:"Fields"`
 }
 
+// Validate is a method of type Rule Interface
+// which returns validation errors
 func (m *MustExist) Validate(cmd *cobra.Command) []validator.ValidationError {
 	return m.validateMustExist(cmd)
 }

--- a/validator/rules/must_exist.go
+++ b/validator/rules/must_exist.go
@@ -28,10 +28,6 @@ type MustExist struct {
 // Validate is a method of type Rule Interface
 // which returns validation errors
 func (m *MustExist) Validate(cmd *cobra.Command) []validator.ValidationError {
-	return m.validateMustExist(cmd)
-}
-
-func (m *MustExist) validateMustExist(cmd *cobra.Command) []validator.ValidationError {
 	var errors []validator.ValidationError
 
 	for field, isTrue := range m.Fields {

--- a/validator/rules/use_matches.go
+++ b/validator/rules/use_matches.go
@@ -23,12 +23,8 @@ type UseMatches struct {
 
 // Validate is a method of type Rule Interface
 // which returns validation errors
+// compares the regexp with Use attribute
 func (u *UseMatches) Validate(cmd *cobra.Command) []validator.ValidationError {
-	return u.validateUse(cmd)
-}
-
-// validateUse compares the regexp with Use attribute
-func (u *UseMatches) validateUse(cmd *cobra.Command) []validator.ValidationError {
 	var errors []validator.ValidationError
 
 	r, err := regexp.Compile(u.Regexp)

--- a/validator/rules/use_matches.go
+++ b/validator/rules/use_matches.go
@@ -1,0 +1,44 @@
+package rules
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/aerogear/charmil/validator"
+	"github.com/spf13/cobra"
+)
+
+// define errors for the UseMatches Rule
+var (
+	ErrInvalidRegexp = errors.New("invalid regexp")
+	ErrRegexMismatch = errors.New("regexp mismatch")
+)
+
+var UseMatchesRule = "USE_MATCHES_RULE"
+
+// UseMatches defines Regexp to be compared
+type UseMatches struct {
+	Regexp string `json:"Regexp"`
+}
+
+// Validate is a method of type Rule Interface
+// which returns validation errors
+func (u *UseMatches) Validate(cmd *cobra.Command) []validator.ValidationError {
+	return u.validateUse(cmd)
+}
+
+// validateUse compares the regexp with Use attribute
+func (u *UseMatches) validateUse(cmd *cobra.Command) []validator.ValidationError {
+	var errors []validator.ValidationError
+
+	r, err := regexp.Compile(u.Regexp)
+	if err != nil {
+		errors = append(errors, validator.ValidationError{Name: "given regexp is invalid", Err: ErrInvalidRegexp, Rule: UseMatchesRule, Cmd: cmd})
+		return errors
+	}
+	if !r.MatchString(cmd.Use) {
+		errors = append(errors, validator.ValidationError{Name: "Use doesn't match with given regexp", Err: ErrRegexMismatch, Rule: UseMatchesRule, Cmd: cmd})
+	}
+
+	return errors
+}


### PR DESCRIPTION
Closes #84 

### Description
- UseMatches rule for validating use with default or user provided regex

### Type of change
 
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer