### PR TITLE
refactor: include config handler in factory

### DIFF
--- a/core/factory/default.go
+++ b/core/factory/default.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aerogear/charmil/core/config"
 	"github.com/aerogear/charmil/core/localize"
 	"github.com/aerogear/charmil/core/logging"
 )
 
 // Default creates new instance of factory for plugins
-func Default(localizer localize.Localizer) *Factory {
+func Default(localizer localize.Localizer, cfgHandler *config.CfgHandler) *Factory {
 
 	// initializing logger
 	loggerFunc := func() (logging.Logger, error) {
@@ -30,7 +31,8 @@ func Default(localizer localize.Localizer) *Factory {
 	}
 
 	return &Factory{
-		Logger:    logger,
-		Localizer: localizer,
+		Logger:     logger,
+		Localizer:  localizer,
+		CfgHandler: cfgHandler,
 	}
 }

--- a/core/factory/factory.go
+++ b/core/factory/factory.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"github.com/aerogear/charmil/core/config"
 	"github.com/aerogear/charmil/core/localize"
 	"github.com/aerogear/charmil/core/logging"
 )
@@ -12,4 +13,6 @@ type Factory struct {
 	Logger logging.Logger
 	// Localizer localizes the text in commands
 	Localizer localize.Localizer
+	// CfgHandler provides the fields required for managing config
+	CfgHandler *config.CfgHandler
 }

--- a/examples/host/main.go
+++ b/examples/host/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aerogear/charmil/core/commands"
 	c "github.com/aerogear/charmil/core/config"
+	"github.com/aerogear/charmil/core/factory"
 	"github.com/aerogear/charmil/examples/plugins/adder"
 	"github.com/aerogear/charmil/examples/plugins/echo"
 	"github.com/spf13/cobra"
@@ -25,6 +26,9 @@ type config struct {
 const cfgFilePath = "./examples/host/config.json"
 
 var (
+	// Stores an instance of the charmil factory
+	cmdFactory *factory.Factory
+
 	// Stores an instance of the charmil config handler
 	h *c.CfgHandler
 
@@ -49,6 +53,9 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Creates a new factory instance with default settings
+	cmdFactory = factory.Default(nil)
 }
 
 func main() {
@@ -62,7 +69,7 @@ func main() {
 	}
 
 	// Stores the root command of the `adder` plugin
-	adderCmd, err := adder.AdderCommand(h)
+	adderCmd, err := adder.AdderCommand(h, cmdFactory)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/host/main.go
+++ b/examples/host/main.go
@@ -55,7 +55,7 @@ func init() {
 	}
 
 	// Creates a new factory instance with default settings
-	cmdFactory = factory.Default(nil)
+	cmdFactory = factory.Default(nil, h)
 }
 
 func main() {
@@ -63,13 +63,13 @@ func main() {
 	cfg.Key4 = "val4"
 
 	// Add plugin CLI into host
-	echoCmd, err := echo.EchoCommand()
+	echoCmd, err := echo.EchoCommand(cmdFactory)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Stores the root command of the `adder` plugin
-	adderCmd, err := adder.AdderCommand(h, cmdFactory)
+	adderCmd, err := adder.AdderCommand(cmdFactory)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/plugins/adder/main.go
+++ b/examples/plugins/adder/main.go
@@ -23,7 +23,7 @@ var cfg = &config{}
 
 // AdderCommand returns the root command of plugin.
 // This will be added to the host CLI as an extension.
-func AdderCommand(h *c.CfgHandler, f *factory.Factory) (*cobra.Command, error) {
+func AdderCommand(f *factory.Factory) (*cobra.Command, error) {
 
 	// Stores the config for localizer
 	cfg.LocConfig = localize.Config{
@@ -39,8 +39,9 @@ func AdderCommand(h *c.CfgHandler, f *factory.Factory) (*cobra.Command, error) {
 	}
 
 	opts := &factory.Factory{
-		Logger:    f.Logger,
-		Localizer: loc,
+		Logger:     f.Logger,
+		Localizer:  loc,
+		CfgHandler: f.CfgHandler,
 	}
 
 	// Stores the root command of plugin
@@ -67,7 +68,7 @@ func AdderCommand(h *c.CfgHandler, f *factory.Factory) (*cobra.Command, error) {
 	}
 
 	// Merges the current plugin config into the host CLI config
-	err = c.MergePluginCfg("adder", h, cfg)
+	err = c.MergePluginCfg("adder", opts.CfgHandler, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/plugins/adder/main.go
+++ b/examples/plugins/adder/main.go
@@ -15,11 +15,6 @@ import (
 //
 // CONSTRAINT: All fields of the config struct need to be exportable
 type config struct {
-	Key5 string
-	Key6 string
-	Key7 string
-	Key8 string
-
 	LocConfig localize.Config
 }
 
@@ -29,12 +24,6 @@ var cfg = &config{}
 // AdderCommand returns the root command of plugin.
 // This will be added to the host CLI as an extension.
 func AdderCommand(h *c.CfgHandler, f *factory.Factory) (*cobra.Command, error) {
-
-	// Sets dummy values into config
-	cfg.Key5 = "val5"
-	cfg.Key6 = "val6"
-	cfg.Key7 = "val7"
-	cfg.Key8 = "val8"
 
 	// Stores the config for localizer
 	cfg.LocConfig = localize.Config{

--- a/examples/plugins/adder/main.go
+++ b/examples/plugins/adder/main.go
@@ -19,6 +19,8 @@ type config struct {
 	Key6 string
 	Key7 string
 	Key8 string
+
+	LocConfig localize.Config
 }
 
 // Initializes a zero-valued struct and stores its address
@@ -26,7 +28,8 @@ var cfg = &config{}
 
 // AdderCommand returns the root command of plugin.
 // This will be added to the host CLI as an extension.
-func AdderCommand(h *c.CfgHandler) (*cobra.Command, error) {
+func AdderCommand(h *c.CfgHandler, f *factory.Factory) (*cobra.Command, error) {
+
 	// Sets dummy values into config
 	cfg.Key5 = "val5"
 	cfg.Key6 = "val6"
@@ -34,26 +37,28 @@ func AdderCommand(h *c.CfgHandler) (*cobra.Command, error) {
 	cfg.Key8 = "val8"
 
 	// Stores the config for localizer
-	locConfig := localize.Config{
+	cfg.LocConfig = localize.Config{
 		Language: language.English,
 		Path:     "examples/plugins/adder/locales/en/adder.en.yaml",
 		Format:   "yaml",
 	}
 
 	// Initializes the localizer by passing config
-	loc, err := localize.InitLocalizer(locConfig)
+	loc, err := localize.InitLocalizer(cfg.LocConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	//Stores a new factory instance with default settings
-	f := factory.Default(loc)
+	opts := &factory.Factory{
+		Logger:    f.Logger,
+		Localizer: loc,
+	}
 
 	// Stores the root command of plugin
 	adderCmd := &cobra.Command{
-		Use:     f.Localizer.LocalizeByID("adder.cmd.use"),
-		Short:   f.Localizer.LocalizeByID("adder.cmd.short"),
-		Example: f.Localizer.LocalizeByID("adder.cmd.example"),
+		Use:     opts.Localizer.LocalizeByID("adder.cmd.use"),
+		Short:   opts.Localizer.LocalizeByID("adder.cmd.short"),
+		Example: opts.Localizer.LocalizeByID("adder.cmd.example"),
 		Args:    cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result := 0
@@ -66,7 +71,7 @@ func AdderCommand(h *c.CfgHandler) (*cobra.Command, error) {
 				result += n
 			}
 
-			f.Logger.Infoln(f.Localizer.LocalizeByID("adder.cmd.resultMessage"), result)
+			opts.Logger.Infoln(opts.Localizer.LocalizeByID("adder.cmd.resultMessage"), result)
 
 			return nil
 		},

--- a/examples/plugins/echo/echo.go
+++ b/examples/plugins/echo/echo.go
@@ -1,43 +1,53 @@
 package echo
 
 import (
+	"log"
+
+	c "github.com/aerogear/charmil/core/config"
 	"github.com/aerogear/charmil/core/factory"
 	"github.com/aerogear/charmil/core/localize"
-	"github.com/aerogear/charmil/core/logging"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/language"
 )
 
-// Options is a type to access factory functions
-// User can limit the options to use comming from factory
-type Options struct {
-	Logger   logging.Logger
-	Localize localize.Localizer
+// Defines the configuration keys of the plugin.
+//
+// CONSTRAINT: All fields of the config struct need to be exportable
+type config struct {
+	LocConfig localize.Config
 }
 
+// Initializes a zero-valued struct and stores its address
+var cfg = &config{}
+
 // Date Command
-func EchoCommand() (*cobra.Command, error) {
+func EchoCommand(f *factory.Factory) (*cobra.Command, error) {
+
+	// Stores the config for localizer
+	cfg.LocConfig = localize.Config{
+		Language: language.English,
+		Path:     "examples/plugins/echo/locales/en/en.yaml",
+		Format:   "yaml"}
 
 	// Initialize localizer providing the language, locals and format of locals file
-	loc, err := localize.InitLocalizer(localize.Config{Language: language.English, Path: "examples/plugins/echo/locales/en/en.yaml", Format: "yaml"})
+	loc, err := localize.InitLocalizer(cfg.LocConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	// Create new/default instance of factory
-	newFactory := factory.Default(loc)
-	opts := &Options{
-		Logger:   newFactory.Logger,
-		Localize: newFactory.Localizer,
+	opts := &factory.Factory{
+		Logger:     f.Logger,
+		Localizer:  loc,
+		CfgHandler: f.CfgHandler,
 	}
 
 	// creating new echo command
 	// using localizer to access default text by ID provided in locals
 	cmd := &cobra.Command{
-		Use:     opts.Localize.LocalizeByID("echo.cmd.use"),
-		Short:   opts.Localize.LocalizeByID("echo.cmd.short"),
-		Long:    opts.Localize.LocalizeByID("echo.cmd.long"),
-		Example: opts.Localize.LocalizeByID("echo.cmd.example"),
+		Use:     opts.Localizer.LocalizeByID("echo.cmd.use"),
+		Short:   opts.Localizer.LocalizeByID("echo.cmd.short"),
+		Long:    opts.Localizer.LocalizeByID("echo.cmd.long"),
+		Example: opts.Localizer.LocalizeByID("echo.cmd.example"),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -46,6 +56,12 @@ func EchoCommand() (*cobra.Command, error) {
 
 			return nil
 		},
+	}
+
+	// Merges the current plugin config into the host CLI config
+	err = c.MergePluginCfg("echo", opts.CfgHandler, cfg)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	return cmd, nil

--- a/examples/plugins/echo/echo.go
+++ b/examples/plugins/echo/echo.go
@@ -19,7 +19,7 @@ type Options struct {
 func EchoCommand() (*cobra.Command, error) {
 
 	// Initialize localizer providing the language, locals and format of locals file
-	loc, err := localize.InitLocalizer(localize.Config{Language: language.English, Path: "examples/plugin/locales/en/en.yaml", Format: "yaml"})
+	loc, err := localize.InitLocalizer(localize.Config{Language: language.English, Path: "examples/plugins/echo/locales/en/en.yaml", Format: "yaml"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
Based on a TODO comment dropped while working on the config package (Ref: [Link](https://github.com/aerogear/charmil/pull/108/commits/4a2f025b6431a88fa4b1ad31d1bece7ac11733eb#diff-13338daeaca64c71d39b900e5c4e96bb600794eebe6df6588a607f051970aaecL55))

Changes made:
- The `Factory` struct should be initialized in the host CLI and passed on to the plugins. But in the current setup of host and plugin examples, the `Factory` was being initialized in the plugins themselves. Added a fix for that.
- Included the `CfgHandler` struct in `Factory` (**as discussed here**: https://github.com/aerogear/charmil/pull/108#discussion_r664903307)
- Modified the `echo` example plugin to use the Config package
- Replace dummy config values in the `adder` example plugin with actual configurations

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Other (please specify): Refactor

### Checklist

- [x] Documentation added for the feature
- [ ] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
