### PR TITLE
refactor: make minor modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-/host_example
-validator_example
+charmil

--- a/starter/.gitignore
+++ b/starter/.gitignore
@@ -18,4 +18,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-/starter
+abc

--- a/starter/Makefile
+++ b/starter/Makefile
@@ -12,7 +12,7 @@ BUILDFLAGS := -gcflags "all=-N -l" $(BUILDFLAGS)
 endif
 
 # The details of the application:
-binary:=starter
+binary:=abc
 
 # Enable Go modules:
 export GO111MODULE=on
@@ -44,11 +44,11 @@ generate:
 # Build binaries
 # NOTE it may be necessary to use CGO_ENABLED=0 for backwards compatibility with centos7 if not using centos7
 binary:
-	go build $(BUILDFLAGS) -ldflags "${GO_LDFLAGS}" -o ${binary} ./cmd/starter
+	go build $(BUILDFLAGS) -ldflags "${GO_LDFLAGS}" -o ${binary} ./cmd/abc
 .PHONY: binary
 
 install:
-	go install -trimpath $(BUILDFLAGS) -ldflags "${GO_LDFLAGS}" ./cmd/starter
+	go install -trimpath $(BUILDFLAGS) -ldflags "${GO_LDFLAGS}" ./cmd/abc
 .PHONY: install
 
 test/unit: install
@@ -72,7 +72,7 @@ docs/check: docs/generate
 .PHONY: docs/check
 
 docs/generate:
-	GENERATE_DOCS=true go run ./cmd/starter
+	GENERATE_DOCS=true go run ./cmd/abc
 .PHONY: docs/generate
 
 docs/generate-modular-docs: docs/generate

--- a/starter/cmd/abc/main.go
+++ b/starter/cmd/abc/main.go
@@ -84,12 +84,19 @@ func abc() *cobra.Command {
 func main() {
 	cmd := abc()
 
-	if err := doc.GenMarkdownTree(cmd, "starter/docs/commands"); err != nil {
-		log.Fatal(err)
+	if err := doc.GenMarkdownTree(cmd, "./docs/commands"); err != nil {
+		cmdFactory.Logger.Errorln(cmdFactory.IOStreams.ErrOut, err)
+		os.Exit(1)
+	}
+
+	// Writes the current config into the local config file
+	if err := h.Save(); err != nil {
+		cmdFactory.Logger.Errorln(cmdFactory.IOStreams.ErrOut, err)
+		os.Exit(1)
 	}
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		cmdFactory.Logger.Errorln(cmdFactory.IOStreams.ErrOut, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### Description
Some minor required changes that I missed while reviewing #155 

Changes made:
- Updated binary names in `.gitignore` files and Makefiles
- Added back the `Save` method (which generates/updates the local config file) to Starter CLI
- Fixed the error: 
  ```bash
  &{0xc00006c120} open starter/docs/commands/root_completion_bash.md: no such file or directory
  ```
- Modified error-printing statements to use the `Logger` and `IOStreams` from the factory