### PR TITLE
fix: create necessary parent directories before crud generation

### DIFF
--- a/pkg/cmd/crud/crud.go
+++ b/pkg/cmd/crud/crud.go
@@ -72,15 +72,13 @@ func generateCrudFiles() error {
 	crudDirPath := flagVars.path + "/crud"
 
 	// Creates a directory using value in the `crudDirPath` variable
-	if _, err := os.Stat(crudDirPath); os.IsNotExist(err) {
-		err := os.Mkdir(crudDirPath, 0755)
-		if err != nil {
-			return err
-		}
+	err := os.MkdirAll(crudDirPath, 0755)
+	if err != nil {
+		return err
 	}
 
 	// Generates CRUD files in the `crud` directory by looping through the template files
-	err := fs.WalkDir(crud.CrudTemplates, ".", func(path string, info fs.DirEntry, err error) error {
+	err = fs.WalkDir(crud.CrudTemplates, ".", func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #189 

### Description
- Resolved the error:
  ```bash
  mkdir ./artifacts/crud: no such file or directory
  ```
- This error used to occur when any of the parent directories present in the path (`artifacts` in this case) didn't exist.

- Fixed this by ensuring all directories in the specified path are created before proceeding with the generation of CRUD commands.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)

### Checklist

- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer
