### PR TITLE
refactor: generate CRUD files in separate packages with root command

### DIFF
--- a/cli/internal/cmd/crud/crud.go
+++ b/cli/internal/cmd/crud/crud.go
@@ -85,7 +85,10 @@ func generateCrudPackages() error {
 				flagVars.localePath = flagVars.crudPath
 			}
 
-			generateCrudFile(info.Name(), ".", flagVars.localePath)
+			err = generateCrudFile(info.Name(), ".", flagVars.localePath)
+			if err != nil {
+				return err
+			}
 
 			return nil
 		}
@@ -112,7 +115,10 @@ func generateCrudPackages() error {
 
 		// Generates CRUD files in separate packages
 		for _, entry := range entries {
-			generateCrudFile(entry.Name(), path, targetPath)
+			err = generateCrudFile(entry.Name(), path, targetPath)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/cli/internal/cmd/crud/crud.go
+++ b/cli/internal/cmd/crud/crud.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/aerogear/charmil/cli/internal/factory"
 	"github.com/aerogear/charmil/cli/internal/template/crud"
@@ -39,7 +40,7 @@ func CrudCommand(f *factory.Factory) (*cobra.Command, error) {
 		Example:       f.Localizer.LocalizeByID("crud.cmd.example"),
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return generateCrudFiles()
+			return generateCrudPackages()
 		},
 	}
 
@@ -68,39 +69,50 @@ func CrudCommand(f *factory.Factory) (*cobra.Command, error) {
 	return cmd, nil
 }
 
-// generateCrudFiles generates the CRUD files in the path specified by the `crudPath` flag
-func generateCrudFiles() error {
-	// Stores path of the directory named `crud` that
-	// will be created to store generated CRUD files
-	crudDirPath := flagVars.crudPath + "/crud"
+// generateCrudPackages generates the CRUD packages in the path specified by the `crudPath` flag
+func generateCrudPackages() error {
 
-	// Creates a directory using value in the `crudDirPath` variable
-	err := os.MkdirAll(crudDirPath, 0755)
-	if err != nil {
-		return err
-	}
-
-	// Generates CRUD files in the `crud` directory by looping through the template files
-	err = fs.WalkDir(crud.CrudTemplates, ".", func(path string, info fs.DirEntry, err error) error {
+	// Generates CRUD packages in the specified path by looping through the template files
+	err := fs.WalkDir(crud.CrudTemplates, ".", func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Excludes non-template files from generation
-		if info.Name() == "." || info.Name() == "tmpl.go" {
+		// Generates the language file
+		if info.Name() == "crud.en.yaml" {
+			// Sets appropriate target path for the locale file
+			if flagVars.localePath == "." {
+				flagVars.localePath = flagVars.crudPath
+			}
+
+			generateCrudFile(info.Name(), ".", flagVars.localePath)
+
 			return nil
 		}
 
-		// Stores the current template file contents as a byte array
-		buf, err := fs.ReadFile(crud.CrudTemplates, info.Name())
+		// Generates the root CRUD command file from template
+		if info.Name() == "root.go" {
+			err = generateFileFromTemplate(info.Name(), flagVars.crudPath, string(crud.RootTemplate), flagVars)
+			if err != nil {
+				return err
+			}
+		}
+
+		if !info.IsDir() || info.Name() == "." {
+			return nil
+		}
+
+		entries, err := crud.CrudTemplates.ReadDir(path)
 		if err != nil {
 			return err
 		}
 
-		// Generate CRUD file from the current template
-		err = generateFileFromTemplate(info.Name(), crudDirPath, string(buf), flagVars)
-		if err != nil {
-			return err
+		// Stores the path where the CRUD file will be generated
+		targetPath := fmt.Sprintf("%s/%s", flagVars.crudPath, info.Name())
+
+		// Generates CRUD files in separate packages
+		for _, entry := range entries {
+			generateCrudFile(entry.Name(), path, targetPath)
 		}
 
 		return nil
@@ -112,20 +124,34 @@ func generateCrudFiles() error {
 	return nil
 }
 
-// generateFileFromTemplate uses the passed contents and data object of a
-// template to generate a new file using the specified file name and output path
-func generateFileFromTemplate(name, path, tmplContent string, tmplData interface{}) error {
-	// Sets appropriate target path for the locale file
-	if name == "crud.en.yaml" && flagVars.localePath != "." {
-		// Creates all necessary parent directories from the specified locale path
-		err := os.MkdirAll(flagVars.localePath, 0755)
-		if err != nil {
-			return err
-		}
+// generateCrudFile takes the target file name, target path and the path
+// of the template as arguments and generates a CRUD file using it.
+func generateCrudFile(fileName, currentPath, targetPath string) error {
 
-		// Sets the target path
-		path = flagVars.localePath
+	// Ensures all parent directories in `targetPath` are created before file generation
+	err := os.MkdirAll(targetPath, 0755)
+	if err != nil {
+		return err
 	}
+
+	// Stores the current template file contents as a byte array
+	buf, err := crud.CrudTemplates.ReadFile(filepath.Join(currentPath, fileName))
+	if err != nil {
+		return err
+	}
+
+	// Generate CRUD file from the current template
+	err = generateFileFromTemplate(fileName, targetPath, string(buf), flagVars)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// generateFileFromTemplate uses the template to generate a
+// new file using the specified file name and output path
+func generateFileFromTemplate(name, path, tmplContent string, tmplData interface{}) error {
 
 	// Creates a new file using the specified name and path
 	f, err := os.Create(fmt.Sprintf("%s/%s", path, name))

--- a/cli/internal/cmd/crud/crud.go
+++ b/cli/internal/cmd/crud/crud.go
@@ -95,7 +95,7 @@ func generateCrudPackages() error {
 
 		// Generates the root CRUD command file from template
 		if info.Name() == "root.go" {
-			err = generateFileFromTemplate(info.Name(), flagVars.crudPath, string(crud.RootTemplate), flagVars)
+			err = generateFileFromTemplate(flagVars.Singular+".go", flagVars.crudPath, string(crud.RootTemplate), flagVars)
 			if err != nil {
 				return err
 			}

--- a/cli/internal/template/crud/create/create.go
+++ b/cli/internal/template/crud/create/create.go
@@ -1,6 +1,6 @@
 // Create file for {{.Singular}} instances
 
-package crud
+package create
 
 import (
 	"github.com/aerogear/charmil/cli/internal/factory"
@@ -34,10 +34,4 @@ func NewCreateCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.autoUse, "use", true, f.Localizer.LocalizeByID("{{.Singular}}.cmd.create.flag.use.description"))
 
 	return cmd
-}
-
-func runCreate(opts *createOptions, f *factory.Factory) error {
-	// Add your implementation here
-
-	return nil
 }

--- a/cli/internal/template/crud/create/create.go
+++ b/cli/internal/template/crud/create/create.go
@@ -14,8 +14,8 @@ type createOptions struct {
 	// You can add more fields here according to your requirements
 }
 
-// NewCreateCommand creates a new command for creating instances.
-func NewCreateCommand(f *factory.Factory) *cobra.Command {
+// GetCreateCommand returns a new command for creating {{.Singular}} instances.
+func GetCreateCommand(f *factory.Factory) *cobra.Command {
 	opts := &createOptions{}
 
 	cmd := &cobra.Command{

--- a/cli/internal/template/crud/create/run.go
+++ b/cli/internal/template/crud/create/run.go
@@ -1,6 +1,6 @@
 package create
 
-import "github.com/aerogear/charmil/core/factory"
+import "github.com/aerogear/charmil/cli/internal/factory"
 
 func runCreate(opts *createOptions, f *factory.Factory) error {
 	// Add your implementation here

--- a/cli/internal/template/crud/create/run.go
+++ b/cli/internal/template/crud/create/run.go
@@ -1,0 +1,9 @@
+package create
+
+import "github.com/aerogear/charmil/core/factory"
+
+func runCreate(opts *createOptions, f *factory.Factory) error {
+	// Add your implementation here
+
+	return nil
+}

--- a/cli/internal/template/crud/crud.en.yaml
+++ b/cli/internal/template/crud/crud.en.yaml
@@ -1,3 +1,17 @@
+# Root CRUD Command
+
+{{.Singular}}.cmd.use:
+  one: {{.Singular}}
+
+{{.Singular}}.cmd.shortDescription:
+  one: {{.Singular}} CRUD commands
+
+{{.Singular}}.cmd.longDescription:
+  one: Contains the commands to perform CRUD operations on {{.Singular}} instances.
+
+{{.Singular}}.cmd.example:
+  one: cli_name {{.Singular}} [create/delete/describe/list/use] [args] [flags]
+
 # Create Command
 
 {{.Singular}}.cmd.create.use:

--- a/cli/internal/template/crud/delete/delete.go
+++ b/cli/internal/template/crud/delete/delete.go
@@ -1,6 +1,6 @@
 // Delete file for {{.Singular}} instances
 
-package crud
+package delete
 
 import (
 	"github.com/aerogear/charmil/cli/internal/factory"
@@ -34,10 +34,4 @@ func NewDeleteCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.force, "yes", "y", false, f.Localizer.LocalizeByID("{{.Singular}}.common.flag.yes"))
 
 	return cmd
-}
-
-func runDelete(opts *deleteOptions, f *factory.Factory) error {
-	// Add your implementation here
-
-	return nil
 }

--- a/cli/internal/template/crud/delete/delete.go
+++ b/cli/internal/template/crud/delete/delete.go
@@ -14,8 +14,8 @@ type deleteOptions struct {
 	// You can add more fields here according to your requirements
 }
 
-// NewDeleteCommand creates a new command for deleting instances.
-func NewDeleteCommand(f *factory.Factory) *cobra.Command {
+// GetDeleteCommand returns a new command for deleting {{.Singular}} instances.
+func GetDeleteCommand(f *factory.Factory) *cobra.Command {
 	opts := &deleteOptions{}
 
 	cmd := &cobra.Command{

--- a/cli/internal/template/crud/delete/run.go
+++ b/cli/internal/template/crud/delete/run.go
@@ -1,6 +1,6 @@
 package delete
 
-import "github.com/aerogear/charmil/core/factory"
+import "github.com/aerogear/charmil/cli/internal/factory"
 
 func runDelete(opts *deleteOptions, f *factory.Factory) error {
 	// Add your implementation here

--- a/cli/internal/template/crud/delete/run.go
+++ b/cli/internal/template/crud/delete/run.go
@@ -1,0 +1,9 @@
+package delete
+
+import "github.com/aerogear/charmil/core/factory"
+
+func runDelete(opts *deleteOptions, f *factory.Factory) error {
+	// Add your implementation here
+
+	return nil
+}

--- a/cli/internal/template/crud/describe/describe.go
+++ b/cli/internal/template/crud/describe/describe.go
@@ -14,8 +14,8 @@ type describeOptions struct {
 	// You can add more fields here according to your requirements
 }
 
-// NewDescribeCommand creates a new command for describing instances.
-func NewDescribeCommand(f *factory.Factory) *cobra.Command {
+// GetDescribeCommand returns a new command for describing {{.Singular}} instances.
+func GetDescribeCommand(f *factory.Factory) *cobra.Command {
 	opts := &describeOptions{}
 
 	cmd := &cobra.Command{

--- a/cli/internal/template/crud/describe/describe.go
+++ b/cli/internal/template/crud/describe/describe.go
@@ -1,6 +1,6 @@
 // Describe file for {{.Singular}} instances
 
-package crud
+package describe
 
 import (
 	"github.com/aerogear/charmil/cli/internal/factory"
@@ -34,10 +34,4 @@ func NewDescribeCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.id, "id", "", f.Localizer.LocalizeByID("{{.Singular}}.common.flag.id"))
 
 	return cmd
-}
-
-func runDescribe(opts *describeOptions, f *factory.Factory) error {
-	// Add your implementation here
-
-	return nil
 }

--- a/cli/internal/template/crud/describe/run.go
+++ b/cli/internal/template/crud/describe/run.go
@@ -1,0 +1,9 @@
+package describe
+
+import "github.com/aerogear/charmil/core/factory"
+
+func runDescribe(opts *describeOptions, f *factory.Factory) error {
+	// Add your implementation here
+
+	return nil
+}

--- a/cli/internal/template/crud/describe/run.go
+++ b/cli/internal/template/crud/describe/run.go
@@ -1,6 +1,6 @@
 package describe
 
-import "github.com/aerogear/charmil/core/factory"
+import "github.com/aerogear/charmil/cli/internal/factory"
 
 func runDescribe(opts *describeOptions, f *factory.Factory) error {
 	// Add your implementation here

--- a/cli/internal/template/crud/list/list.go
+++ b/cli/internal/template/crud/list/list.go
@@ -16,8 +16,8 @@ type listOptions struct {
 	// You can add more fields here according to your requirements
 }
 
-// NewListCommand creates a new command for listing instances.
-func NewListCommand(f *factory.Factory) *cobra.Command {
+// GetListCommand returns a new command for listing {{.Singular}} instances.
+func GetListCommand(f *factory.Factory) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{

--- a/cli/internal/template/crud/list/list.go
+++ b/cli/internal/template/crud/list/list.go
@@ -1,6 +1,6 @@
 // List file for {{.Singular}} instances
 
-package crud
+package list
 
 import (
 	"github.com/aerogear/charmil/cli/internal/factory"
@@ -38,10 +38,4 @@ func NewListCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.search, "search", "", "", f.Localizer.LocalizeByID("{{.Singular}}.list.flag.search"))
 
 	return cmd
-}
-
-func runList(opts *listOptions, f *factory.Factory) error {
-	// Add your implementation here
-
-	return nil
 }

--- a/cli/internal/template/crud/list/run.go
+++ b/cli/internal/template/crud/list/run.go
@@ -1,0 +1,9 @@
+package list
+
+import "github.com/aerogear/charmil/core/factory"
+
+func runList(opts *listOptions, f *factory.Factory) error {
+	// Add your implementation here
+
+	return nil
+}

--- a/cli/internal/template/crud/list/run.go
+++ b/cli/internal/template/crud/list/run.go
@@ -1,6 +1,6 @@
 package list
 
-import "github.com/aerogear/charmil/core/factory"
+import "github.com/aerogear/charmil/cli/internal/factory"
 
 func runList(opts *listOptions, f *factory.Factory) error {
 	// Add your implementation here

--- a/cli/internal/template/crud/root.go
+++ b/cli/internal/template/crud/root.go
@@ -1,0 +1,29 @@
+package crud
+
+var RootTemplate = []byte(`package {{.Singular}}
+
+import (
+	"github.com/aerogear/charmil/core/factory"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     f.Localizer.LocalizeByID("{{.Singular}}.cmd.use"),
+		Short:   f.Localizer.LocalizeByID("{{.Singular}}.cmd.shortDescription"),
+		Long:    f.Localizer.LocalizeByID("{{.Singular}}.cmd.longDescription"),
+		Example: f.Localizer.LocalizeByID("{{.Singular}}.cmd.example"),
+		Args:    cobra.MinimumNArgs(1),
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(
+		create.NewCreateCommand(f),
+		describe.NewDescribeCommand(f),
+		delete.NewDeleteCommand(f),
+		list.NewListCommand(f),
+		use.NewUseCommand(f),
+	)
+
+	return cmd
+}`)

--- a/cli/internal/template/crud/root.go
+++ b/cli/internal/template/crud/root.go
@@ -3,7 +3,7 @@ package crud
 var RootTemplate = []byte(`package {{.Singular}}
 
 import (
-	"github.com/aerogear/charmil/core/factory"
+	"github.com/aerogear/charmil/cli/internal/factory"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/internal/template/crud/root.go
+++ b/cli/internal/template/crud/root.go
@@ -18,11 +18,11 @@ func NewCommand(f *factory.Factory) *cobra.Command {
 
 	// Add sub-commands
 	cmd.AddCommand(
-		create.NewCreateCommand(f),
-		describe.NewDescribeCommand(f),
-		delete.NewDeleteCommand(f),
-		list.NewListCommand(f),
-		use.NewUseCommand(f),
+		create.GetCreateCommand(f),
+		describe.GetDescribeCommand(f),
+		delete.GetDeleteCommand(f),
+		list.GetListCommand(f),
+		use.GetUseCommand(f),
 	)
 
 	return cmd

--- a/cli/internal/template/crud/use/run.go
+++ b/cli/internal/template/crud/use/run.go
@@ -1,6 +1,6 @@
 package use
 
-import "github.com/aerogear/charmil/core/factory"
+import "github.com/aerogear/charmil/cli/internal/factory"
 
 func runUse(opts *useOptions, f *factory.Factory) error {
 	// Add your implementation here

--- a/cli/internal/template/crud/use/run.go
+++ b/cli/internal/template/crud/use/run.go
@@ -1,0 +1,9 @@
+package use
+
+import "github.com/aerogear/charmil/core/factory"
+
+func runUse(opts *useOptions, f *factory.Factory) error {
+	// Add your implementation here
+
+	return nil
+}

--- a/cli/internal/template/crud/use/use.go
+++ b/cli/internal/template/crud/use/use.go
@@ -1,6 +1,6 @@
 // Use file for {{.Singular}} instances
 
-package crud
+package use
 
 import (
 	"github.com/aerogear/charmil/cli/internal/factory"
@@ -32,10 +32,4 @@ func NewUseCommand(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.id, "id", "", f.Localizer.LocalizeByID("{{.Singular}}.use.flag.id"))
 
 	return cmd
-}
-
-func runUse(opts *useOptions, f *factory.Factory) error {
-	// Add your implementation here
-
-	return nil
 }

--- a/cli/internal/template/crud/use/use.go
+++ b/cli/internal/template/crud/use/use.go
@@ -13,8 +13,8 @@ type useOptions struct {
 	// You can add more fields here according to your requirements
 }
 
-// NewUseCommand creates a new command for using instances.
-func NewUseCommand(f *factory.Factory) *cobra.Command {
+// GetUseCommand returns a new command for using {{.Singular}} instances.
+func GetUseCommand(f *factory.Factory) *cobra.Command {
 	opts := &useOptions{}
 
 	cmd := &cobra.Command{

--- a/docs/src/charmil_cli.md
+++ b/docs/src/charmil_cli.md
@@ -27,30 +27,6 @@ $ charmil add CMD_NAME
 
 ## Crud Command
 
-With the help of `crud` command, developers can eliminate a lot of boilerplate in CLIs containing multiple services that perform standard CRUD operations.
+Helps developers generate CRUD commands for their CLI.
 
-Using a set of pre-defined templates, this command generates CRUD files in the directory specified with the `path` flag.
-
-These generated files can be modified by developers to fit their own needs.
-
-### Usage:
-
-```bash
-charmil crud [flags]
-```
-
-### Example:
-
-```bash
-$ charmil crud --singular=kafka --plural=kafkas --crudpath="./kafka" --localepath="./cmd/locales/en"
-```
-
-### Flags:
-
-```
-  -c, --crudpath string     path where CRUD files need to be generated (default ".")
-  -h, --help                help for crud
-  -l, --localepath string   path where the language file needs to be generated (default ".")
-  -p, --plural string       name in plural form (REQUIRED)
-  -s, --singular string     name in singular form (REQUIRED)
-```
+- #### [Link to detailed documentation on the Charmil CRUD Command](./charmil_cli_crud.md)

--- a/docs/src/charmil_cli_crud.md
+++ b/docs/src/charmil_cli_crud.md
@@ -54,10 +54,10 @@ charmil crud [flags]
      ┣ 📂use
      ┃ ┣ 📜use.go
      ┃ ┗ 📜run.go
-     ┗ 📜root.go
+     ┗ 📜kafka.go
   ```
 
-- Once the CRUD packages have been generated, go to the generated `root.go` file and add all the missing imports there.
+- Once the CRUD packages have been generated, go to the generated `kafka.go` file and add all the missing imports there.
 
 - Using the following line, add the generated CRUD commands to your CLI:
 

--- a/docs/src/charmil_cli_crud.md
+++ b/docs/src/charmil_cli_crud.md
@@ -2,9 +2,9 @@
 
 - With the help of the `charmil crud` command, developers can eliminate a lot of boilerplate in CLIs containing multiple services that perform standard CRUD operations.
 
-- Using a set of pre-defined templates, this command generates CRUD command packages in the directory specified with the `crudpath` flag and the corresponding language file in the directory specified with the `localepath` flag.
+- Using a set of pre-defined templates, this command generates CRUD command packages in the directory specified by the `crudpath` flag as well as its corresponding language file in the directory specified by the `localepath` flag.
 
-- These generated files can be modified by developers to fit their own needs.
+- These generated files can then be modified by developers to fit their own needs.
 
 ## Usage:
 
@@ -22,7 +22,7 @@ charmil crud [flags]
   -s, --singular string     name in singular form (REQUIRED)
 ```
 
-## Example:
+## Steps to use:
 
 - Let's say you need to generate CRUD commands for managing your Kafka instances, the following command can be used for the same:
 
@@ -56,3 +56,15 @@ charmil crud [flags]
      ┃ ┗ 📜run.go
      ┗ 📜root.go
   ```
+
+- Once the CRUD packages have been generated, go to the generated `root.go` file and add all the missing imports there.
+
+- Using the following line, add the generated CRUD commands to your CLI:
+
+  ```go
+  cmd.AddCommand(kafka.NewCommand(cmdFactory))
+  ```
+
+  where `cmd` refers to your CLI's parent command and `cmdFactory` refers to the factory instance.
+
+Now you're all set to use the CRUD commands in your CLI.

--- a/docs/src/charmil_cli_crud.md
+++ b/docs/src/charmil_cli_crud.md
@@ -1,0 +1,58 @@
+# Charmil CRUD Generator
+
+- With the help of the `charmil crud` command, developers can eliminate a lot of boilerplate in CLIs containing multiple services that perform standard CRUD operations.
+
+- Using a set of pre-defined templates, this command generates CRUD command packages in the directory specified with the `crudpath` flag and the corresponding language file in the directory specified with the `localepath` flag.
+
+- These generated files can be modified by developers to fit their own needs.
+
+## Usage:
+
+```bash
+charmil crud [flags]
+```
+
+## Flags:
+
+```
+  -c, --crudpath string     path where CRUD files need to be generated (default ".")
+  -h, --help                help for crud
+  -l, --localepath string   path where the language file needs to be generated (default ".")
+  -p, --plural string       name in plural form (REQUIRED)
+  -s, --singular string     name in singular form (REQUIRED)
+```
+
+## Example:
+
+- Let's say you need to generate CRUD commands for managing your Kafka instances, the following command can be used for the same:
+
+  ```bash
+  $ charmil crud --singular=kafka --plural=kafkas --crudpath="./kafka" --localepath="./cmd/locales/en"
+  ```
+
+- On running the command mentioned above, the required files will be generated in your project in the following structure:
+
+  ```code
+  📦Your CLI
+   ┣ 📂cmd
+   ┃ ┗ 📂locales
+   ┃   ┗ 📂en
+   ┃     ┗ 📜crud.en.yaml
+   ┗ 📂kafka
+     ┣ 📂create
+     ┃ ┣ 📜create.go
+     ┃ ┗ 📜run.go
+     ┣ 📂delete
+     ┃ ┣ 📜delete.go
+     ┃ ┗ 📜run.go
+     ┣ 📂describe
+     ┃ ┣ 📜describe.go
+     ┃ ┗ 📜run.go
+     ┣ 📂list
+     ┃ ┣ 📜list.go
+     ┃ ┗ 📜run.go
+     ┣ 📂use
+     ┃ ┣ 📜use.go
+     ┃ ┗ 📜run.go
+     ┗ 📜root.go
+  ```

--- a/starter/cmd/cli/main.go
+++ b/starter/cmd/cli/main.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"os"
 
+	"github.com/aerogear/charmil/cli/internal/factory"
 	"github.com/aerogear/charmil/core/config"
 	"github.com/aerogear/charmil/core/localize"
-	"github.com/aerogear/charmil/starter/internal/factory"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"golang.org/x/text/language"


### PR DESCRIPTION
# Changes made:

 - **Divided every single CRUD file into two different files**:
	 - Removed the `run` functions from the main CRUD files and moved them into separate files named `run.go`. (Ref: https://github.com/aerogear/charmil/pull/171#discussion_r675129181)
	 
	- For example, the create command is now divided into 2 files ie. `create.go` and `run.go` where `run.go` contains definition of the function that will be called whenever the generated create command is run.

 - **Generate CRUD files as separate packages**:
	 - Each CRUD command file is generated in a separate package.

	 - For example, the `create.go` and `run.go` (which contains the `run` function for the create command) files are now generated under a package named `create`.
 - **Added a root command template**:
	 - Included a template file named `root.go` which acts as a parent command to all the generated CRUD commands.
	 - Instead of adding every single generated CRUD command to their CLI, developers will now only need to add this single root command to their CLI.
	 - For example, using the following line, the developers will be able to add the generated CRUD commands to their CLI:

		  ```go
		  cmd.AddCommand(kafka.NewCommand(cmdFactory))
		  ```

		  Here `cmd` refers to the developer's CLI parent command and `cmdFactory` refers to the factory instance.

 - **Added detailed dev usage docs for Charmil CRUD Generator**

&nbsp;
# Example to show how this PR will affect our CRUD generator:
On running the command:
```bash
charmil crud --singular=kafka --plural=kafkas --crudpath="./kafka" 
```
- **Before making the changes through this PR**:
```code
	    📦User's CLI
	     ┗ 📂crud
	       ┣ 📜create.go
	       ┣ 📜delete.go
	       ┣ 📜describe.go
	       ┣ 📜list.go
	       ┗ 📜use.go
```
- **After making the changes through this PR**:
```code
	    📦User's CLI
	     ┗ 📂kafka
	       ┣ 📂create
	       ┃ ┣ 📜create.go
	       ┃ ┗ 📜run.go
	       ┣ 📂delete
	       ┃ ┣ 📜delete.go
	       ┃ ┗ 📜run.go
	       ┣ 📂describe
	       ┃ ┣ 📜describe.go
	       ┃ ┗ 📜run.go
	       ┣ 📂list
	       ┃ ┣ 📜list.go
	       ┃ ┗ 📜run.go
	       ┣ 📂use
	       ┃ ┣ 📜use.go
	       ┃ ┗ 📜run.go
	       ┗ 📜root.go
```

PS: I've excluded the generated language file from the above file structure example for simplicity.