### PR TITLE
feat: disable validation rule option

### DIFF
--- a/docs/src/validator.md
+++ b/docs/src/validator.md
@@ -59,6 +59,27 @@ for _, errs := range validationErr {
 }
 ```
 
+## Disable a Rule
+All the rules provided by charmil are enabled by default. If you want to turn off particular rule or rules, there is an `Disable` option in `RuleOptions` in each rule.
+
+```go
+ruleCfg := rules.ValidatorConfig{
+	ValidatorRules: rules.ValidatorRules{
+		Punctuation: Punctuation{
+			RuleOptions: validator.RuleOptions{
+				Disable: true,
+			},
+		},
+		UseMatches: UseMatches{
+			RuleOptions: validator.RuleOptions{
+				Disable: true,
+			},
+		},
+
+	},
+}
+```
+
 ## Ignore Commands
 Sometimes during development, you want to pass the tests for certain commands, but at the same time use Validator for tests. Validation can be skipped/ignored for the commands, mentioned in the validator configuration.
 To ignore the commands you need to specify the path of the command in validator configuration.

--- a/validator/rules/cmd_test.go
+++ b/validator/rules/cmd_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"testing"
 
+	"github.com/aerogear/charmil/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,9 @@ func Test_ExecuteCommand(t *testing.T) {
 					"Use":     {Min: 1},
 					"Example": {Min: 3},
 					"Long":    {Min: 5},
+				},
+				RuleOptions: validator.RuleOptions{
+					Disable: true,
 				},
 			},
 			MustExist: MustExist{

--- a/validator/rules/config.go
+++ b/validator/rules/config.go
@@ -81,12 +81,19 @@ func ValidatorConfigToRuleConfig(validatorConfig *ValidatorConfig, ruleConfig *R
 	validatorConfig = &configHelper
 
 	// append rules to execute
-	ruleConfig.Rules = append(
-		ruleConfig.Rules,
-		&validatorConfig.Length,
-		&validatorConfig.MustExist,
-		&validatorConfig.UseMatches,
-		&validatorConfig.ExampleMatches,
-		&validatorConfig.Punctuation,
-	)
+	if !validatorConfig.Length.RuleOptions.Disable {
+		ruleConfig.Rules = append(ruleConfig.Rules, &validatorConfig.Length)
+	}
+	if !validatorConfig.MustExist.RuleOptions.Disable {
+		ruleConfig.Rules = append(ruleConfig.Rules, &validatorConfig.MustExist)
+	}
+	if !validatorConfig.UseMatches.RuleOptions.Disable {
+		ruleConfig.Rules = append(ruleConfig.Rules, &validatorConfig.UseMatches)
+	}
+	if !validatorConfig.ExampleMatches.RuleOptions.Disable {
+		ruleConfig.Rules = append(ruleConfig.Rules, &validatorConfig.ExampleMatches)
+	}
+	if !validatorConfig.Punctuation.RuleOptions.Disable {
+		ruleConfig.Rules = append(ruleConfig.Rules, &validatorConfig.Punctuation)
+	}
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -7,6 +7,7 @@ import (
 // RuleOptions is present in each rule
 // to control the options limited to the rule
 type RuleOptions struct {
+	Disable      bool
 	Verbose      bool
 	SkipCommands map[string]bool
 }


### PR DESCRIPTION
Closes #197 

### Description
- Add a Disable option in RulesOption for disabling the rule

I tried doing it with loop, but it gives problem. Here is the sample code which I tried.
```go
r := reflect.ValueOf(validatorConfig.ValidatorRules)
for i := 0; i < r.NumField(); i++ {
	a := r.Field(i)
        fmt.Println(a.FieldByName("RuleOptions").FieldByName("Disable").String())

	if a.FieldByName("RuleOptions").FieldByName("Disable").String() == "false" {
	 	ruleConfig.Rules = append(ruleConfig.Rules, a.interface{}.(Rules))  // here is the issue
        }

	fmt.Println(ruleConfig.Rules)
}
```

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)

### Checklist
- [x] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer

